### PR TITLE
Renaming project to SafeChat Slack Bot

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -28,4 +28,4 @@ jobs:
         uses: codecov/codecov-action@v4.0.1
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-          slug: marcieltorres/slack-bot-no-cpf
+          slug: marcieltorres/safe-chat-slack-bot

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,8 +1,8 @@
 # Code of Conduct
 
-To be a truly great community, `slack-bot-no-cpf` needs to welcome developers from all walks of life, with different backgrounds, and with a wide range of experience. A diverse and friendly community will have more great ideas, more unique perspectives, and produce more great code. We will work diligently to make the `slack-bot-no-cpf` community welcoming to everyone.
+To be a truly great community, `safe-chat-slack-bot` needs to welcome developers from all walks of life, with different backgrounds, and with a wide range of experience. A diverse and friendly community will have more great ideas, more unique perspectives, and produce more great code. We will work diligently to make the `safe-chat-slack-bot` community welcoming to everyone.
 
-To give clarity of what is expected of our members, `slack-bot-no-cpf` has adopted the code of conduct defined by [contributor-covenant.org](https://www.contributor-covenant.org). This document is used across many open source communities, and we think it articulates our values well. The full text is copied below:
+To give clarity of what is expected of our members, `safe-chat-slack-bot` has adopted the code of conduct defined by [contributor-covenant.org](https://www.contributor-covenant.org). This document is used across many open source communities, and we think it articulates our values well. The full text is copied below:
 
 ### Contributor Code of Conduct v2.1
 

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ ifneq (,$(wildcard ./.env))
     export
 endif
 
-APP_NAME="slack-bot-no-cpf"
-IMAGE_NAME="slack-bot-no-cpf"
+APP_NAME="safe-chat-slack-bot"
+IMAGE_NAME="safe-chat-slack-bot"
 VERSION="latest"
 MAIN_ENTRYPOINT="src/bot.py"
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Slack Bot No CPF [![codecov](https://codecov.io/gh/marcieltorres/slack-bot-no-cpf/graph/badge.svg?token=V0T0I3SI3P)](https://codecov.io/gh/marcieltorres/slack-bot-no-cpf)
+# SafeChat Slack Bot [![codecov](https://codecov.io/gh/marcieltorres/safe-chat-slack-bot/graph/badge.svg?token=V0T0I3SI3P)](https://codecov.io/gh/marcieltorres/safe-chat-slack-bot)
 
-A simple slack bot that analyzes messages sent on channels and warns about possible sensitive data from someone, such as a social security number, for example.
+The SafeChat is a simple slack bot that analyzes messages sent on channels and warns about possible sensitive data from someone, such as a social security number, for example.
 
 ## How bot works on slack workspace
 
@@ -15,7 +15,6 @@ A simple slack bot that analyzes messages sent on channels and warns about possi
 - [Ruff](https://github.com/astral-sh/ruff)
 - [Slack Bolt](https://pypi.org/project/slack-bolt/)
 - [i18n](https://docs.python.org/3/library/i18n.html)
-
 
 
 *Please pay attention on **pre-requisites** resources that you must install/configure.*

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,4 +2,4 @@
 
 ## Reporting a Vulnerability
 
-If you found a security bug, report it opening an [issue](https://github.com/marcieltorres/slack-bot-no-cpf/issues/new/choose) describing how to reproduce.
+If you found a security bug, report it opening an [issue](https://github.com/marcieltorres/safe-chat-slack-bot/issues/new/choose) describing how to reproduce.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
 version: "3.4"
 services:
-  slack-bot-no-cpf:
+  safe-chat-slack-bot:
     tty: true
-    image: "slack-bot-no-cpf"
+    image: "safe-chat-slack-bot"
     stdin_open: true
     build:
       context: .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
-name = "slack-bot-no-cpf"
+name = "safe-chat-slack-bot"
 version = "0.1.0"
-description = "A python boilerplate project using poetry"
+description = "SafeChat is a simple slack bot that analyzes messages sent on channels and warns about possible sensitive data from someone, such as a social security number, for example"
 authors = ["Marciel Torres <marcielribeirotorres@gmail.com>"]
 license = "MIT"
 

--- a/settings.conf
+++ b/settings.conf
@@ -1,5 +1,5 @@
 [default]
-app_name=slack-bot-no-cpf
+app_name=safe-chat-slack-bot
 
 [dev]
 


### PR DESCRIPTION
closes: https://github.com/marcieltorres/slack-bot-no-cpf/issues/12

## What changes do you are proposing? 

We are renaming the project to `SafeChat Slack Bot`, this name is more generic to make this bot universal 🚀 